### PR TITLE
Correctly encode special characters in the `href` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,9 +27,16 @@ const create = (input, options, menuLevel = 0) => input.map(line => {
 
 	const prefix = '--'.repeat(menuLevel);
 
+	function encodehref(link) {
+		link = encodeURI(link);
+		link = link.replace(/'/g, '%27');
+		link = link.replace(/&/g, '%26');
+		return link;
+	}
+
 	return text.split('\n').map(textLine => {
 		const options = Object.keys(line).map(key => {
-			const value = key === 'href' ? encodeURI(line[key]) : line[key];
+			const value = key === 'href' ? encodehref(line[key]) : line[key];
 			return `${key}="${value}"`;
 		}).join(' ');
 

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ const create = (input, options, menuLevel = 0) => input.map(line => {
 
 	const prefix = '--'.repeat(menuLevel);
 
-	function encodehref(link) {
+	function encodeHref(link) {
 		link = encodeURI(link);
 		link = link.replace(/'/g, '%27');
 		link = link.replace(/&/g, '%26');
@@ -36,7 +36,7 @@ const create = (input, options, menuLevel = 0) => input.map(line => {
 
 	return text.split('\n').map(textLine => {
 		const options = Object.keys(line).map(key => {
-			const value = key === 'href' ? encodehref(line[key]) : line[key];
+			const value = key === 'href' ? encodeHref(line[key]) : line[key];
 			return `${key}="${value}"`;
 		}).join(' ');
 

--- a/test.js
+++ b/test.js
@@ -62,3 +62,22 @@ test('`text` property validation', t => {
 		bitbar([{text: 1}]);
 	}, errorMessage);
 });
+
+test('correctly encodes special characters in the `href` option', t => {
+	const actual = bitbar.create([
+		{
+			text: 'Single Quote',
+			href: 'https://www.youtube.com/watch?v=\'9auOCbH5Ns4'
+		},
+		{
+			text: 'Ampercent',
+			href: 'https://www.youtube.com/watch?v=&9auOCbH5Ns4'
+		}
+	]);
+	const expected = `
+Single Quote|href="https://www.youtube.com/watch?v=%279auOCbH5Ns4"
+Ampercent|href="https://www.youtube.com/watch?v=%269auOCbH5Ns4"
+`.trim();
+
+	t.is(actual, expected);
+});

--- a/test.js
+++ b/test.js
@@ -70,12 +70,17 @@ test('correctly encodes special characters in the `href` option', t => {
 			href: 'https://www.youtube.com/watch?v=\'9auOCbH5Ns4'
 		},
 		{
+			text: 'Double Quotes',
+			href: 'https://www.youtube.com/watch?v="9auOCbH5Ns4"'
+		},
+		{
 			text: 'Ampercent',
 			href: 'https://www.youtube.com/watch?v=&9auOCbH5Ns4'
 		}
 	]);
 	const expected = `
 Single Quote|href="https://www.youtube.com/watch?v=%279auOCbH5Ns4"
+Double Quotes|href="https://www.youtube.com/watch?v=%229auOCbH5Ns4%22"
 Ampercent|href="https://www.youtube.com/watch?v=%269auOCbH5Ns4"
 `.trim();
 


### PR DESCRIPTION
Fixes #11
Closes #16

Encoding both single quotes and ampercent special characters as mentioned by op.

Created bitbar plugin and tested the functionality.

Took some inspiration from pull request #16.


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#11: URLs with special characters don't work](https://issuehunt.io/repos/49339397/issues/11)
---

IssueHunt has been backed by the following sponsors. [Become a sponsor](https://issuehunt.io/membership/members)
</details>
<!-- /Issuehunt content-->