### PR TITLE
Accept top-level separator in the TypeScript types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -120,8 +120,8 @@ declare const bitbar: {
 	```
 	*/
 	(
-		items: readonly (string | bitbar.Options | symbol)[],
-		options?: bitbar.BitbarOptions,
+		items: readonly (string | bitbar.Options | typeof bitbar.separator)[],
+		options?: bitbar.BitbarOptions
 	): void;
 
 	/**

--- a/index.d.ts
+++ b/index.d.ts
@@ -120,7 +120,7 @@ declare const bitbar: {
 	```
 	*/
 	(
-		items: readonly (string | bitbar.Options)[],
+		items: readonly (string | bitbar.Options | symbol)[],
 		options?: bitbar.BitbarOptions,
 	): void;
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -8,7 +8,8 @@ expectType<void>(
 			color: bitbar.darkMode ? 'white' : 'red',
 			dropdown: false
 		},
-	]),
+		bitbar.separator
+	])
 );
 
 expectType<boolean>(bitbar.darkMode);

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -8,7 +8,23 @@ expectType<void>(
 			color: bitbar.darkMode ? 'white' : 'red',
 			dropdown: false
 		},
-		bitbar.separator
+		bitbar.separator,
+		{
+			text: 'Unicorns',
+			color: '#ff79d7',
+			submenu: [
+				{
+					text: ':tv: Video',
+					href: 'https://www.youtube.com/watch?v=9auOCbH5Ns4'
+				},
+				{
+					text: ':book: Wiki',
+					href: 'https://en.wikipedia.org/wiki/Unicorn'
+				}
+			]
+		},
+		bitbar.separator,
+		'Ponies'
 	])
 );
 


### PR DESCRIPTION
Here's a fix.

I also added the rest of the code from the readme, just to be safe, to the test.