### PR TITLE
Correctly override default settings 

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ const create = (input, options, menuLevel = 0) => input.map(line => {
 		return '--'.repeat(menuLevel) + '---';
 	}
 
-	line = Object.assign(line, options);
+	line = {...options, ...line};
 
 	const {text} = line;
 	if (typeof text !== 'string') {

--- a/test.js
+++ b/test.js
@@ -86,3 +86,24 @@ Ampercent|href="https://www.youtube.com/watch?v=%269auOCbH5Ns4"
 
 	t.is(actual, expected);
 });
+
+test('correctly overrides global settings', t => {
+	const actual = bitbar.create([
+		{
+			text: 'Default font'
+		},
+		{
+			text: 'Overriden font',
+			font: 'Comic Sans MS'
+		}
+	], {
+		font: 'Arial'
+	});
+
+	const expected = `
+Default font|font="Arial"
+Overriden font|font="Comic Sans MS"
+`.trim();
+
+	t.is(actual, expected);
+});


### PR DESCRIPTION
Fixes #22.

`ava` was not a fan of Object.assign, so I changed it to a spread operator instead.

Maybe this could change Node version requirements?