### PR TITLE
Allow nested submenus in the TypeScript types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -94,7 +94,7 @@ declare namespace bitbar {
 		/**
 		Add a submenu to the item. A submenu is composed of an array of items.
 		*/
-		submenu?: (string | BitbarOptions)[];
+		submenu?: (string | Options)[];
 	}
 }
 


### PR DESCRIPTION
Fixes #24 

The Options type is probably not needed now, but it would be a breaking-ish change to remove it.