### PR TITLE
Fix `text` option being mandatory in top-level options

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -96,6 +96,8 @@ declare namespace bitbar {
 		*/
 		submenu?: (string | Options)[];
 	}
+
+	export type TopLevelOptions = Omit<Options, 'text'>
 }
 
 declare const bitbar: {
@@ -121,7 +123,7 @@ declare const bitbar: {
 	*/
 	(
 		items: readonly (string | bitbar.Options | typeof bitbar.separator)[],
-		options?: bitbar.BitbarOptions
+		options?: bitbar.TopLevelOptions
 	): void;
 
 	/**

--- a/index.js
+++ b/index.js
@@ -18,6 +18,10 @@ const create = (input, options, menuLevel = 0) => input.map(line => {
 		return '--'.repeat(menuLevel) + '---';
 	}
 
+	if (options && typeof options.text !== 'undefined') {
+		throw new TypeError('The `text` property is not supported on top-level options. Use the `text` property on an item instead');
+	}
+
 	line = {
 		...options,
 		...line

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,5 +1,5 @@
-import {expectType} from 'tsd';
-import bitbar = require('.');
+import { expectAssignable, expectNotAssignable, expectType } from 'tsd';
+import bitbar = require('.')
 
 expectType<void>(
 	bitbar([
@@ -29,3 +29,7 @@ expectType<void>(
 );
 
 expectType<boolean>(bitbar.darkMode);
+
+expectNotAssignable<bitbar.TopLevelOptions>({text: 'Unicorns'})
+
+expectAssignable<bitbar.TopLevelOptions>({font: 'Comic Sans MS'})

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,4 +1,4 @@
-import { expectAssignable, expectNotAssignable, expectType } from 'tsd';
+import {expectAssignable, expectNotAssignable, expectType} from 'tsd';
 import bitbar = require('.')
 
 expectType<void>(

--- a/test.js
+++ b/test.js
@@ -107,3 +107,17 @@ Overriden font|font="Comic Sans MS"
 
 	t.is(actual, expected);
 });
+
+test('`text` property on top-level options throws TypeError', t => {
+	const errorMessage = 'The `text` property is not supported on top-level options. Use the `text` property on an item instead';
+
+	t.throws(() => {
+		bitbar([
+			{
+				text: '❤'
+			}
+		], {
+			text: 'Override'
+		});
+	}, errorMessage);
+});


### PR DESCRIPTION
Fixes #26