### PR TITLE
Add isxbar

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -127,7 +127,7 @@ export const isDarkMode: boolean;
 /**
 Check whether the script is running from xbar.
 */
-export const isxbar: boolean;
+export const isXbar: boolean;
 
 /**
 Create a plugin for xbar.

--- a/index.d.ts
+++ b/index.d.ts
@@ -125,6 +125,11 @@ Check whether dark mode is enabled.
 export const isDarkMode: boolean;
 
 /**
+Check whether the script is running from xbar.
+*/
+export const isxbar: boolean;
+
+/**
 Create a plugin for xbar.
 
 @param items - xbar items.

--- a/index.js
+++ b/index.js
@@ -4,6 +4,8 @@ export const separator = Symbol('separator');
 
 export const isDarkMode = process.env.XBARDarkMode === '1';
 
+export const isxbar = process.env.__CFBundleIdentifier === 'com.xbarapp.app';
+
 const encodeHref = url => {
 	url = encodeURI(url);
 	url = url.replace(/'/g, '%27');

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ export const separator = Symbol('separator');
 
 export const isDarkMode = process.env.XBARDarkMode === '1';
 
-export const isxbar = process.env.__CFBundleIdentifier === 'com.xbarapp.app';
+export const isXbar = process.env.__CFBundleIdentifier === 'com.xbarapp.app';
 
 const encodeHref = url => {
 	url = encodeURI(url);

--- a/readme.md
+++ b/readme.md
@@ -83,3 +83,7 @@ Add a separator.
 ### isDarkMode
 
 A boolean of whether macOS dark mode is enabled.
+
+### isXbar
+
+A boolean to check if script is running from xbar or terminal.

--- a/readme.md
+++ b/readme.md
@@ -82,8 +82,12 @@ Add a separator.
 
 ### isDarkMode
 
-A boolean of whether macOS dark mode is enabled.
+Type: `boolean`
+
+Check whether dark mode is enabled.
 
 ### isXbar
 
-A boolean to check if script is running from xbar or terminal.
+Type: `boolean`
+
+Check whether the script is running from xbar.


### PR DESCRIPTION
This is a suggestion to add `isxbar` to determine whether the script is running from xbar or terminal.
I use this conditional quite a lot in all of my scripts to behave differently when running the script in terminal.
<img width="272" alt="Screenshot 2022-03-30 at 15 12 09@2x" src="https://user-images.githubusercontent.com/1941540/160772963-7af2e7ed-0674-47f0-b5d0-13273d935bab.png">

Example:
```javascript
import xbar, { separator, isDarkMode, isxbar } from '@sindresorhus/xbar'

if (isxbar) {
    xbar([...]);
} else {
    console.log('Greetings from terminal!');
}
```
https://github.com/sindresorhus/xbar/blob/c62c24a98d295b0f0d5190d6293b109aa70f923c/index.js#L7
Let me know what you think