### PR TITLE
Fix XBARDarkMode variable

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ import process from 'node:process';
 
 export const separator = Symbol('separator');
 
-export const isDarkMode = process.env.XBARDarkMode === '1';
+export const isDarkMode = process.env.XBARDarkMode === 'true';
 
 export const isXbar = process.env.__CFBundleIdentifier === 'com.xbarapp.app';
 


### PR DESCRIPTION
From my own test, it seems that the global variable `XBARDarkMode` is defined as `true` as a string instead of `1` as a string.

I've tested it on xbar v2.1.7-beta (latest version as of today).